### PR TITLE
[Photoframe step5] 화면 전환 기능 수정 및 readme 수정

### DIFF
--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A59B0E7423E97A6100FA7D25 /* YellowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59B0E7323E97A6100FA7D25 /* YellowViewController.swift */; };
+		A59B0E7623E97F2C00FA7D25 /* BlueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59B0E7523E97F2C00FA7D25 /* BlueViewController.swift */; };
 		A5CC78D623E7C47900F99D81 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CC78D523E7C47900F99D81 /* AppDelegate.swift */; };
 		A5CC78D823E7C47900F99D81 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CC78D723E7C47900F99D81 /* SceneDelegate.swift */; };
 		A5CC78DA23E7C47900F99D81 /* FirstViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CC78D923E7C47900F99D81 /* FirstViewController.swift */; };
@@ -27,6 +29,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A59B0E7323E97A6100FA7D25 /* YellowViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YellowViewController.swift; sourceTree = "<group>"; };
+		A59B0E7523E97F2C00FA7D25 /* BlueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueViewController.swift; sourceTree = "<group>"; };
 		A5CC78D223E7C47900F99D81 /* PhotoFrame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoFrame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5CC78D523E7C47900F99D81 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5CC78D723E7C47900F99D81 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -86,6 +90,8 @@
 				A5CC78E023E7C47B00F99D81 /* Assets.xcassets */,
 				A5CC78E223E7C47B00F99D81 /* LaunchScreen.storyboard */,
 				A5CC78E523E7C47B00F99D81 /* Info.plist */,
+				A59B0E7323E97A6100FA7D25 /* YellowViewController.swift */,
+				A59B0E7523E97F2C00FA7D25 /* BlueViewController.swift */,
 			);
 			path = PhotoFrame;
 			sourceTree = "<group>";
@@ -200,8 +206,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A59B0E7423E97A6100FA7D25 /* YellowViewController.swift in Sources */,
 				A5CC78DA23E7C47900F99D81 /* FirstViewController.swift in Sources */,
 				A5CC78D623E7C47900F99D81 /* AppDelegate.swift in Sources */,
+				A59B0E7623E97F2C00FA7D25 /* BlueViewController.swift in Sources */,
 				A5CC78D823E7C47900F99D81 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -377,7 +377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = hanseop.PhotoFrame;
+				PRODUCT_BUNDLE_IDENTIFIER = hanseop.PhotoFrame1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -395,7 +395,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = hanseop.PhotoFrame;
+				PRODUCT_BUNDLE_IDENTIFIER = hanseop.PhotoFrame1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -27,7 +27,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1ni-SD-ON7">
-                                <rect key="frame" x="192" y="260" width="30" height="30"/>
+                                <rect key="frame" x="364" y="44" width="30" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="다음"/>
                                 <connections>
@@ -73,20 +73,29 @@
             </objects>
             <point key="canvasLocation" x="0.0" y="0.0"/>
         </scene>
-        <!--View Controller-->
+        <!--Yellow View Controller-->
         <scene sceneID="DOk-K1-db6">
             <objects>
-                <viewController id="cX3-IS-ZvX" sceneMemberID="viewController">
+                <viewController id="cX3-IS-ZvX" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="BfS-uw-LNE">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qm9-L2-URN">
-                                <rect key="frame" x="192" y="263" width="30" height="30"/>
+                                <rect key="frame" x="364" y="20" width="30" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="다음"/>
                                 <connections>
                                     <segue destination="gCc-7Z-fBv" kind="show" id="uEq-hX-U70"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bVF-yk-r3u">
+                                <rect key="frame" x="28" y="20" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="닫기"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="s84-cx-eVk" eventType="touchUpInside" id="hTY-ns-jxr"/>
+                                    <action selector="closeButtonTouched:" destination="cX3-IS-ZvX" eventType="touchUpInside" id="tnY-Ki-IfM"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -96,22 +105,38 @@
                     <navigationItem key="navigationItem" id="wde-6w-5J5"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WEM-gs-oBn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="s84-cx-eVk" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="1457.9710144927537" y="0.0"/>
         </scene>
-        <!--View Controller-->
+        <!--Blue View Controller-->
         <scene sceneID="Zy0-R5-Fhp">
             <objects>
-                <viewController id="gCc-7Z-fBv" sceneMemberID="viewController">
+                <viewController id="gCc-7Z-fBv" customClass="BlueViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="cU1-sf-ecu">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xBz-bO-SUH">
+                                <rect key="frame" x="28" y="20" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="닫기">
+                                    <color key="titleColor" cocoaTouchSystemColor="tableCellGroupedBackgroundColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="closeButtonToched:" destination="iWk-yQ-FCj" eventType="touchUpInside" id="7rr-O7-RzP"/>
+                                    <action selector="closeButtonTouched:" destination="iWk-yQ-FCj" eventType="touchUpInside" id="9dz-WF-aHq"/>
+                                    <action selector="closeButtonTouched:" destination="gCc-7Z-fBv" eventType="touchUpInside" id="G5B-Z5-yUX"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="wmb-Mh-v0o"/>
                     </view>
                     <navigationItem key="navigationItem" id="agj-c8-TaP"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mUv-7w-ZDp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="iWk-yQ-FCj" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="2190" y="0.0"/>
         </scene>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -86,7 +86,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="다음"/>
                                 <connections>
-                                    <segue destination="gCc-7Z-fBv" kind="show" id="uEq-hX-U70"/>
+                                    <action selector="nextButtonTouched:" destination="cX3-IS-ZvX" eventType="touchUpInside" id="VIS-sb-AQQ"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bVF-yk-r3u">
@@ -112,9 +112,9 @@
         <!--Blue View Controller-->
         <scene sceneID="Zy0-R5-Fhp">
             <objects>
-                <viewController id="gCc-7Z-fBv" customClass="BlueViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="BlueViewController" id="gCc-7Z-fBv" customClass="BlueViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="cU1-sf-ecu">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xBz-bO-SUH">

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -16,6 +16,27 @@ class BlueViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        print(#file, #line, #function, #column)
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print(#file, #line, #function, #column)
     }
 }

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -1,0 +1,21 @@
+//
+//  BlueViewController.swift
+//  PhotoFrame
+//
+//  Created by 신한섭 on 2020/02/04.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import UIKit
+
+class BlueViewController: UIViewController {
+
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+}

--- a/PhotoFrame/PhotoFrame/FirstViewController.swift
+++ b/PhotoFrame/PhotoFrame/FirstViewController.swift
@@ -19,16 +19,35 @@ class FirstViewController: UIViewController {
         self.firstLabel.alpha=0.5
     }
     
-
-    
     @IBAction func closeButtonTouchedBlue(_ sender: Any) {
         self.dismiss(animated: true, completion: nil)
     }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         print(#file, #line, #function, #column)
         changeFont(self.firstLabel)
         
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print(#file, #line, #function, #column)
     }
     
     func changeFont(_ label:UILabel){

--- a/PhotoFrame/PhotoFrame/FirstViewController.swift
+++ b/PhotoFrame/PhotoFrame/FirstViewController.swift
@@ -19,6 +19,11 @@ class FirstViewController: UIViewController {
         self.firstLabel.alpha=0.5
     }
     
+
+    
+    @IBAction func closeButtonTouchedBlue(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         print(#file, #line, #function, #column)

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -14,6 +14,12 @@ class YellowViewController: UIViewController {
            self.dismiss(animated: true, completion: nil)
     }
     
+    @IBAction func nextButtonTouched(_ sender: Any) {
+        let vc=self.storyboard?.instantiateViewController(withIdentifier: "BlueViewController") as! BlueViewController
+        vc.modalTransitionStyle = .coverVertical
+        self.present(vc,animated: true,completion: nil)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         print(#file, #line, #function, #column)

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -1,0 +1,21 @@
+//
+//  YellowViewController.swift
+//  PhotoFrame
+//
+//  Created by 신한섭 on 2020/02/04.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import UIKit
+
+class YellowViewController: UIViewController {
+
+    @IBAction func closeButtonTouched(_ sender: Any) {
+           self.dismiss(animated: true, completion: nil)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+}

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -16,6 +16,27 @@ class YellowViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        print(#file, #line, #function, #column)
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print(#file, #line, #function, #column)
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,22 +1,74 @@
-## 버튼 누르기 전
+## 초기화면
 
-<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/73727127-3dfd2480-4774-11ea-84d6-79bb81181090.png">
+<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/73740629-dc48b480-478b-11ea-9c02-963d75d6fbde.png">
 
-## 버튼 누른 후
+## 다음 버튼 누른 후
 
-<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/73727133-42294200-4774-11ea-9b0a-1e3655d32fd8.png">
+<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/73740632-df43a500-478b-11ea-8f32-ac50843e6595.png">
 
 
 
-## 버튼 누른 후
+## 다음 버튼 누른 후
 
-<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/73727146-45243280-4774-11ea-9d55-8b7e02cd4b4e.png">
+<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/73740635-e10d6880-478b-11ea-890b-e20cbc35beda.png">
+
+
+
+## 닫기 버튼 누른 후
+
+<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/73740641-e36fc280-478b-11ea-986b-9151f900f808.png">
+
+## 닫기 버튼 누른 후
+
+<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/73740646-e5d21c80-478b-11ea-8d24-3c63e41b48fd.png">
 
 ### 변경 사항
 
-* viewController를 이용해서 scene을 추가함
-* button에 이벤트를 등록해서 button 클릭 시 scene 전환.
+* viewController 클래스를 생성해서 scene과 바인딩 함.
+* 각 신의 라이프 사이클마다 print(**#file**, **#line**, **#function**, **#column**) 코드 삽입하여 등장 시기 파악
+* yellow 에서 blue 로 화면 전환 시 segue를 이용하지 않고 yellow에 연결된 viewController 클래스에서 스토리 보드에 접근하여 blue에 해당하는 viewController 객체로 직접 전환
+
+### 뷰 컨트롤러
+
+view를 제어하는 controller 객체. view의 프로퍼티를 가지고있으면서 사용자의 이벤트에 따라 적절히 프로퍼티를 조작함.
+
+### 라이프 사이클
+
+* init
+  * 지정된 번들의 nib 파일을 사용하여 새로 초기화 된 뷰 컨트롤러를 반환
+  * nib 파일 : 인터페이스 빌더에서 생성한 객체들을 직렬화하여 저장하는 파일로, UI를 구성하는 객체들을 저장
+
+* loadView
+  * controller가 관리하는 view를 생성함
+* viewDidLoad
+  * controller의 view가 메모리에 로드된 후에 호출 됨
+* viewWillAppear
+  * view controller에 view가 추가될 것임을 알림 (보여지기 직전에)
+* viewDidAppear
+  * view controller에 view가 추가되었음을 알림(보여지고 난 후)
+* viewWillDisappear
+  * view controller에 view 제거될 것임을 알림
+* viewDidDisappear
+  * view controller에 view가 제거 되었음을 알림
+* viewDidUnload
+  * controller의 view가 메모리에서 언로드 되었음을 알림
+
+### 화면 전환 시 라이프 사이클의 변화
+
+* Scene A 에서 Scene B로 이동할 때
+  1. viewDidLoad() - A
+  2. viewWillAppear() - A
+  3. viewDidAppear() - A
+  4. viewWillDisappear() - A
+  5. viewDidLoad() - B
+  6. viewWillAppear() - B
+  7. viewDidAppear() - B
+* Scene B를 종료하고 Scene A로 이동할 때
+  1. viewWillDisappear() - B
+  2. viewWillAppear() - A
+  3. viewDidDisappear() - B
+  4. viewDidAppear() -A
 
 ### 완료 시간
 
-2020-02-04-17:30
+2020-02-04-20:40


### PR DESCRIPTION
* 기능 수정
  * view에 닫기 버튼 추가하여 해당 view를 닫을 수 있게 수정
  * view와 viewController 클래스를 연결하여 view 내의 프로퍼티에 접근 가능
  * yellow에서 blue로 화면 전환 시 segue 대신 코드로 화면 전환 구현

* readme 수정
  * 작동 스크린샷 첨부
  * view controller의 라이프 사이클 설명 추가
  * 화면 전환 시 라이프 사이클의 변화 설명 추가