### PR TITLE
Step 6

### DIFF
--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -82,7 +82,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <connections>
-                                    <segue destination="3UZ-Uw-wQ6" kind="presentation" modalPresentationStyle="fullScreen" id="VcH-ph-yNf"/>
+                                    <segue destination="3UZ-Uw-wQ6" kind="presentation" id="VcH-ph-yNf"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eqa-xY-vD0">
@@ -108,7 +108,7 @@
             <objects>
                 <viewController id="3UZ-Uw-wQ6" customClass="BlueViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ipg-ax-08l">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fmk-Ov-evx">

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -22,9 +22,9 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="14W-R5-Qd9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1368" y="392"/>
+            <point key="canvasLocation" x="2276.8115942028985" y="391.74107142857139"/>
         </scene>
-        <!--Item 1-->
+        <!--First View Controller-->
         <scene sceneID="5CI-YW-XVG">
             <objects>
                 <viewController id="4ZF-tM-B9u" customClass="FirstViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
@@ -59,7 +59,7 @@
                         <viewLayoutGuide key="safeArea" id="dIK-l8-FSH"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Item 1" id="ACh-ie-tib"/>
+                    <navigationItem key="navigationItem" id="Zum-g4-wJY"/>
                     <connections>
                         <outlet property="firstDescription" destination="E9u-hj-KNC" id="HfT-Tu-Xow"/>
                         <outlet property="photoLabel" destination="FXy-qw-qof" id="hZb-8L-N0S"/>
@@ -67,14 +67,14 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="SV2-zP-1E0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1366.6666666666667" y="-215.625"/>
+            <point key="canvasLocation" x="2276.8115942028985" y="-215.625"/>
         </scene>
         <!--Yellow View Controller-->
         <scene sceneID="xTZ-RW-yoX">
             <objects>
                 <viewController id="Dzv-od-Coq" customClass="YellowViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="BLO-v4-owt">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="553-Mr-Sk4">
@@ -101,7 +101,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="AQd-oX-RaL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2075" y="-216"/>
+            <point key="canvasLocation" x="2984.057971014493" y="-216.29464285714286"/>
         </scene>
         <!--Blue View Controller-->
         <scene sceneID="Sbq-PS-Xb8">
@@ -129,7 +129,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8Bb-Do-KJg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2830.434782608696" y="-216.29464285714286"/>
+            <point key="canvasLocation" x="3740.579710144928" y="-216.29464285714286"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="CrW-97-tMe">
@@ -141,13 +141,32 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
-                        <segue destination="4ZF-tM-B9u" kind="relationship" relationship="viewControllers" id="MzG-Wy-RpO"/>
+                        <segue destination="wub-E7-Hh0" kind="relationship" relationship="viewControllers" id="MzG-Wy-RpO"/>
                         <segue destination="dt4-lX-SOq" kind="relationship" relationship="viewControllers" id="7Cq-Cc-Mj6"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Yb4-ei-yeq" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="417" y="74"/>
+        </scene>
+        <!--Item 1-->
+        <scene sceneID="p90-m1-nxe">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="wub-E7-Hh0" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item 1" id="ACh-ie-tib"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="j9Y-gu-dtD">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="4ZF-tM-B9u" kind="relationship" relationship="rootViewController" id="1FT-pH-0G1"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="H74-IG-VHw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1366.6666666666667" y="-215.625"/>
         </scene>
     </scenes>
     <resources>

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -82,7 +82,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <connections>
-                                    <segue destination="3UZ-Uw-wQ6" kind="presentation" id="VcH-ph-yNf"/>
+                                    <segue destination="3UZ-Uw-wQ6" kind="show" id="VcH-ph-yNf"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eqa-xY-vD0">
@@ -108,7 +108,7 @@
             <objects>
                 <viewController id="3UZ-Uw-wQ6" customClass="BlueViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ipg-ax-08l">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fmk-Ov-evx">

--- a/PhotoFrame/PhotoFrame/BlueViewController.swift
+++ b/PhotoFrame/PhotoFrame/BlueViewController.swift
@@ -14,7 +14,7 @@ class BlueViewController: UIViewController {
         
     }
     @IBAction func closeButtonTouched(_ sender: Any) {
-        self.dismiss(animated: true)
+        self.navigationController?.popViewController(animated: true)
     }
     
 }

--- a/PhotoFrame/PhotoFrame/FirstViewController.swift
+++ b/PhotoFrame/PhotoFrame/FirstViewController.swift
@@ -16,7 +16,6 @@ class FirstViewController: UIViewController {
         self.firstDescription.text = "Zeke의 사진액자"
         self.firstDescription.adjustsFontSizeToFitWidth = true
         self.firstDescription.textAlignment = .center
-
     }
     @IBOutlet var photoLabel: UILabel!
     @IBOutlet var firstDescription: UILabel!

--- a/PhotoFrame/PhotoFrame/YellowViewController.swift
+++ b/PhotoFrame/PhotoFrame/YellowViewController.swift
@@ -25,7 +25,7 @@ class YellowViewController: UIViewController {
         print(#file, #line, #function, #column)
     }
     @IBAction func closeButtonTouched(_ sender: UIButton) {
-        self.dismiss(animated: true)
+        self.navigationController?.popViewController(animated: true)
     }
     
 }

--- a/README.md
+++ b/README.md
@@ -2,21 +2,17 @@
 
 
 
-## Step-5(ViewController프로그래밍)
+## Step-6(Container ViewController)
 
 ## 요구사항
 
-- 사진액자 - Scene과 Segue 요구사항을 구현한 상태로 시작한다.
-- [뷰컨트롤러 강의 슬라이드](http://public.codesquad.kr/jk/photoframe-ViewController.pdf)를 읽고 학습한다.
-- 스토리보드 구성 요소와 클래스 코드와 연결해서 동작을 확장한다.
+- 사진액자 - ViewController 요구사항을 구현한 상태로 시작한다.
+- [뷰컨트롤러 컨테이너 강의 슬라이드](http://public.codesquad.kr/jk/photoframe-ViewController-Containers.pdf)를 읽고 학습한다.
+- 내비게이션 컨트롤러(Navigation Controller)를 Embed 시켜서 동작하도록 개선한다.
 - 실행하고 새로운 화면을 캡처해서 readme.md 파일에 포함한다.
 
 
 
 ## 실행 화면
 
-<img width="1257" alt="스크린샷 2021-02-09 오후 5 21 11" src="https://user-images.githubusercontent.com/42647277/107336123-1b76b780-6afc-11eb-95a3-ecce3b59c0f3.png">
-
-<img width="1257" alt="스크린샷 2021-02-09 오후 5 21 23" src="https://user-images.githubusercontent.com/42647277/107336187-2893a680-6afc-11eb-89f3-9c9c091b47fa.png">
-
-
+<img width="280" alt="스크린샷 2021-02-09 오후 8 39 30" src="https://user-images.githubusercontent.com/42647277/107358609-f0e62800-6b16-11eb-928e-83cf00387fd9.png"><img width="280" alt="스크린샷 2021-02-09 오후 8 37 11" src="https://user-images.githubusercontent.com/42647277/107358449-bda39900-6b16-11eb-8936-e6f7ded9de4b.png"><img width="280" alt="스크린샷 2021-02-09 오후 8 37 30" src="https://user-images.githubusercontent.com/42647277/107358473-c6946a80-6b16-11eb-9915-9ad12949f742.png">


### PR DESCRIPTION
### 과정

- First Scene에 NavigationController를 emed하였다.
- Yellow Scene과 Blue Scene에 있는 뒤로 버튼들을 dismiss()메소드를 popViewController()메소드로 수정하였다.
- 하지만 마지막 연결인 Blue Scene에서 뒤로가기 버튼이 작동하지 않아 원인을 찾고 화면전환의 문제인것을 알고 수정



### 시도

- 세그웨이를 선택하여 화면전환을 할 수 있는데 화면전환은 show, show detail, present modally, present as popover 이렇게 4가지 모두 시도.(Navigation Cotroller에서는 show만 뒤로가기 기능이 작동하고 나머지 전환들은 작동하지 않는다.)



### 고민

- Blue Scene에서 다시 Yellow Scene으로 되돌아오기 위해 닫기 버튼을 눌렀지만 아무반응도 하지않았다.
- 차이점을 살펴보자면 First Scene -> Yellow Scene, Yellow Scene -> Blue Scene 이 두가지의 화면전환 방식을 다르게 구현한 것이다. 그렇다면 정확히 이유는 무엇일까?
- modal로 화면전환을 하였을때 나타난 뷰 컨트롤러를 닫으려면 항상 dismiss()메소드를 사용해야하고, navigationController에서 popViewController()메소드를 통해 그 전 화면으로 되돌아가야 한다는것을 알게되었다.