### PR TITLE
뷰컨트롤러 생명주기 학습

### DIFF
--- a/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
+++ b/PhotoFrame/PhotoFrame.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7122F35E25D26F53000F9FED /* PinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7122F35D25D26F53000F9FED /* PinkViewController.swift */; };
+		7122F36325D271C8000F9FED /* GreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7122F36225D271C8000F9FED /* GreenViewController.swift */; };
 		71D15ECD25D2282D00B600E9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D15ECC25D2282D00B600E9 /* AppDelegate.swift */; };
 		71D15ECF25D2282D00B600E9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D15ECE25D2282D00B600E9 /* SceneDelegate.swift */; };
 		71D15ED125D2282D00B600E9 /* FirstViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D15ED025D2282D00B600E9 /* FirstViewController.swift */; };
@@ -17,6 +19,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7122F35D25D26F53000F9FED /* PinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinkViewController.swift; sourceTree = "<group>"; };
+		7122F36225D271C8000F9FED /* GreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreenViewController.swift; sourceTree = "<group>"; };
 		71D15EC925D2282D00B600E9 /* PhotoFrame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoFrame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		71D15ECC25D2282D00B600E9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		71D15ECE25D2282D00B600E9 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -58,11 +62,13 @@
 		71D15ECB25D2282D00B600E9 /* PhotoFrame */ = {
 			isa = PBXGroup;
 			children = (
+				7122F35D25D26F53000F9FED /* PinkViewController.swift */,
 				71D15ECC25D2282D00B600E9 /* AppDelegate.swift */,
 				71D15ECE25D2282D00B600E9 /* SceneDelegate.swift */,
 				71D15ED025D2282D00B600E9 /* FirstViewController.swift */,
 				71D15EE125D228A700B600E9 /* SecondViewController.swift */,
 				71D15ED225D2282D00B600E9 /* Main.storyboard */,
+				7122F36225D271C8000F9FED /* GreenViewController.swift */,
 				71D15ED525D2282F00B600E9 /* Assets.xcassets */,
 				71D15ED725D2282F00B600E9 /* LaunchScreen.storyboard */,
 				71D15EDA25D2282F00B600E9 /* Info.plist */,
@@ -140,10 +146,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7122F36325D271C8000F9FED /* GreenViewController.swift in Sources */,
 				71D15EE225D228A700B600E9 /* SecondViewController.swift in Sources */,
 				71D15ED125D2282D00B600E9 /* FirstViewController.swift in Sources */,
 				71D15ECD25D2282D00B600E9 /* AppDelegate.swift in Sources */,
 				71D15ECF25D2282D00B600E9 /* SceneDelegate.swift in Sources */,
+				7122F35E25D26F53000F9FED /* PinkViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
+++ b/PhotoFrame/PhotoFrame/Base.lproj/Main.storyboard
@@ -89,10 +89,10 @@
             </objects>
             <point key="canvasLocation" x="903" y="593"/>
         </scene>
-        <!--View Controller-->
+        <!--Pink View Controller-->
         <scene sceneID="fE4-Bl-Jpe">
             <objects>
-                <viewController modalPresentationStyle="fullScreen" id="pnR-B1-lnb" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="fullScreen" id="pnR-B1-lnb" customClass="PinkViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kZY-fu-ws2">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -103,7 +103,16 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <state key="normal" title="다음"/>
                                 <connections>
-                                    <segue destination="6eJ-yM-406" kind="showDetail" id="QeU-M6-76d"/>
+                                    <action selector="nextToGreenView:" destination="pnR-B1-lnb" eventType="touchUpInside" id="54s-vc-d4Y"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ifV-Sy-fea">
+                                <rect key="frame" x="190" y="505" width="35" height="36"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <state key="normal" title="닫기"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="pnR-B1-lnb" eventType="touchUpInside" id="328-Cf-ErM"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -111,21 +120,37 @@
                         <color key="backgroundColor" red="1" green="0.96965854121275097" blue="0.93562492007173648" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     </view>
                     <navigationItem key="navigationItem" id="1Y4-PC-3MY"/>
+                    <connections>
+                        <segue destination="6eJ-yM-406" kind="show" identifier="ShowGreen" id="Ce9-Ax-m6h"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7vr-Ah-Qdt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1612" y="-84"/>
         </scene>
-        <!--View Controller-->
+        <!--Green View Controller-->
         <scene sceneID="bhw-st-AkM">
             <objects>
-                <viewController modalPresentationStyle="fullScreen" id="6eJ-yM-406" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="fullScreen" id="6eJ-yM-406" customClass="GreenViewController" customModule="PhotoFrame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="96Z-Du-e6e">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SvK-zT-bAc">
+                                <rect key="frame" x="190" y="505" width="35" height="36"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <state key="normal" title="닫기"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="pnR-B1-lnb" eventType="touchUpInside" id="SEy-hW-WWG"/>
+                                    <action selector="closeButtonTouched:" destination="6eJ-yM-406" eventType="touchUpInside" id="Zrc-ML-SW4"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="twm-e6-L82"/>
                         <color key="backgroundColor" red="0.86987242573339196" green="1" blue="0.94690556476944499" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     </view>
+                    <navigationItem key="navigationItem" id="obY-cc-lo1"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="I4t-oq-jqw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/PhotoFrame/PhotoFrame/GreenViewController.swift
+++ b/PhotoFrame/PhotoFrame/GreenViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  GreenViewController.swift
 //  PhotoFrame
 //
 //  Created by 서우석 on 2021/02/09.
@@ -7,26 +7,19 @@
 
 import UIKit
 
-class FirstViewController: UIViewController {
-    
-    @IBOutlet weak var firstLabel: UILabel!
-    @IBOutlet weak var firstDescription: UILabel!
-    
+class GreenViewController: UIViewController {
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.firstLabel.text = "Ray의 사진액자"
-        self.firstDescription.text = "Created by Suh"
-        self.firstDescription.textColor = UIColor.white
-        self.firstDescription.backgroundColor = UIColor.blue
-        self.firstDescription.font = UIFont.boldSystemFont(ofSize: 15)
         print(#file, #line, #function, #column)
+        // Do any additional setup after loading the view.
     }
+    
 
-    @IBAction func nextButtonTouched(_ sender: Any) {
-        self.firstLabel.textColor = UIColor.blue
-        self.firstLabel.backgroundColor = UIColor.yellow
-        self.firstLabel.alpha = 0.5
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
     }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         print(#file, #line, #function, #column)
@@ -46,5 +39,14 @@ class FirstViewController: UIViewController {
         super.viewDidDisappear(animated)
         print(#file, #line, #function, #column)
     }
-}
+    /*
+    // MARK: - Navigation
 
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/PhotoFrame/PhotoFrame/PinkViewController.swift
+++ b/PhotoFrame/PhotoFrame/PinkViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  PinkViewController.swift
 //  PhotoFrame
 //
 //  Created by 서우석 on 2021/02/09.
@@ -7,26 +7,22 @@
 
 import UIKit
 
-class FirstViewController: UIViewController {
-    
-    @IBOutlet weak var firstLabel: UILabel!
-    @IBOutlet weak var firstDescription: UILabel!
-    
+class PinkViewController: UIViewController {
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.firstLabel.text = "Ray의 사진액자"
-        self.firstDescription.text = "Created by Suh"
-        self.firstDescription.textColor = UIColor.white
-        self.firstDescription.backgroundColor = UIColor.blue
-        self.firstDescription.font = UIFont.boldSystemFont(ofSize: 15)
         print(#file, #line, #function, #column)
+        // Do any additional setup after loading the view.
     }
-
-    @IBAction func nextButtonTouched(_ sender: Any) {
-        self.firstLabel.textColor = UIColor.blue
-        self.firstLabel.backgroundColor = UIColor.yellow
-        self.firstLabel.alpha = 0.5
+    
+    @IBAction func nextToGreenView(_ sender: Any) {
+        performSegue(withIdentifier: "ShowGreen", sender: sender)
     }
+    
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         print(#file, #line, #function, #column)
@@ -46,5 +42,14 @@ class FirstViewController: UIViewController {
         super.viewDidDisappear(animated)
         print(#file, #line, #function, #column)
     }
-}
+    /*
+    // MARK: - Navigation
 
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/PhotoFrame/PhotoFrame/SecondViewController.swift
+++ b/PhotoFrame/PhotoFrame/SecondViewController.swift
@@ -13,4 +13,23 @@ class SecondViewController: UIViewController {
         super.viewDidLoad()
         print(#file, #line, #function, #column)
     }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        print(#file, #line, #function, #column)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        print(#file, #line, #function, #column)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -87,3 +87,64 @@ segue연결시 iOS13부터 modalPresentation 디폴트값 변경 => fullscreen �
 
 - 세번째 화면
 <img src="https://user-images.githubusercontent.com/74946802/107326639-21b26700-6aef-11eb-8830-3987e32a64e0.png" width="300" height="600">
+
+# Step.5
+
+- View Controller의 생명주기
+<img src="https://user-images.githubusercontent.com/74946802/107330692-414c8e00-6af5-11eb-9cfa-4b525c81f16d.jpeg" width="350" height="500">
+
+#### viewDidLoad
+
+시스템에 의해 자동 호출
+
+일반적으로 리소스를 초기화하거나 초기화면 구성 용도
+
+화면이 처음 호출될 때 한번만 실행
+
+처음 한번만 실행되는 초기화 코드의 경우 viewDidLoad에 작성
+
+#### viewWillAppear
+
+뷰가 나타날 거라는 신호를 컨트롤러에 알리는 역할
+
+뷰가 나타나기 직전에 호출되며 viewDidLoad와 다름
+
+앱 실행 시 viewDidLoad -> viewWillAppear순으로 호출
+
+가장 큰 차이점은 다른 뷰로 이동했다가 돌아왔을 때는 viewWillAppear만 호출
+
+다른 뷰로 이동했다가 돌아왔을 때도 처리해야하는 작업은 viewWillAppear에 작성
+
+#### viewDidAppear
+
+뷰가 화면에 나타났다는 신호를 컨트롤러에 알리는 역할
+
+화면에 적용될 애니메이션을 그려주는 역할
+
+뷰가 화면에 나타난 직후에 호출
+
+위 내용을 제외하고는 viewWillAppear와 거의 같음
+
+#### viewWillDisappear
+
+뷰가 사라지기 직전에 호출
+
+뷰가 삭제되려고 하는 것을 컨트롤러에 알리는 역할
+
+#### viewDidDisappear
+
+뷰 컨트롤러가 제거됐을 때 호출
+
+- 첫번째 화면 -> 두번째 화면 -> 첫번째 화면 실행 순서
+
+<img width="168" alt="스크린샷 2021-02-09 오후 5 10 40" src="https://user-images.githubusercontent.com/74946802/107334615-47913900-6afa-11eb-8932-8346b55ca68d.png"> <img width="168" alt="스크린샷 2021-02-09 오후 5 10 51" src="https://user-images.githubusercontent.com/74946802/107334631-4d871a00-6afa-11eb-984e-be2026567914.png"> <img width="172" alt="스크린샷 2021-02-09 오후 5 11 01" src="https://user-images.githubusercontent.com/74946802/107334657-54ae2800-6afa-11eb-88ae-135c063d5fda.png">
+
+?? viewDidLoad가 왜 계속 실행되는지...?
+
+<img width="219" alt="스크린샷 2021-02-10 오후 2 07 47" src="https://user-images.githubusercontent.com/74946802/107467580-a497f800-6ba9-11eb-8553-e935f2ba9cf5.png">
+
+루트 뷰 컨트롤러를 TabBar로 사용하는 뷰컨트롤러끼리는 정상 작동
+
+이전 무한 viewDidLoad호출은 일반 viewController끼리 Segue(show)사용해서 계속 새로운 페이지로 이동하는 현상
+
+- Segue 삭제후 코드로 구현


### PR DESCRIPTION
뷰컨트롤러 생명주기 실습 중, viewDidLoad 반복 호출 현상 발견하여 의문이 있었으나, 오전 수업 중 Segue(show)를 통해 이동할 경우 계속 새로운 페이지를 만들어 온다는 사실을 이해하여 의문점 해결 됐음 -> 추후 네비게이션/탭바 컨트롤러로 확인해보니 viewDidLoad반복 호출 안되는 것 확인 완료

그렇다면 일반 뷰컨트롤러끼리 Segue(show)로 연결할 경우 이동할 때마다 이전 페이지가 메모리에서 삭제된다는 개념인데, 앱 실행속도 저하에 원인이 될 수 있는 건 아닌지...?

Segue삭제후 performSegue통해서 코드후현 완료